### PR TITLE
add arm64 target

### DIFF
--- a/native/ortex/.cargo/config.toml
+++ b/native/ortex/.cargo/config.toml
@@ -12,3 +12,5 @@ rustflags = [
 ]
 [target.x86_64-unknown-linux-gnu]
 rustflags = [ "-Clink-args=-Wl,-rpath,$ORIGIN" ]
+[target.aarch64-unknown-linux-gnu]
+rustflags = [ "-Clink-args=-Wl,-rpath,$ORIGIN" ]


### PR DESCRIPTION
i've specified an additional rpath flag for linux arm64 targets. ortex will now compile on my tested device: Arm Cortex A76