### PR TITLE
adding concat functionality

### DIFF
--- a/lib/ortex/backend.ex
+++ b/lib/ortex/backend.ex
@@ -107,6 +107,23 @@ defmodule Ortex.Backend do
     end
   end
 
+  @impl true
+  def concatenate(out, tensors, axis) do
+    if not Enum.all?(tensors, fn t -> t.type == out.type end) do
+      raise "Ortex does not currently support concatenation of vectors with differing types."
+    end
+
+    tensor_refs =
+      Enum.map(tensors, fn t ->
+        %T{data: %B{ref: ref}} = t
+        ref
+      end)
+
+    type = out.type
+
+    %{out | data: %B{ref: Ortex.Native.concatenate(tensor_refs, type, axis)}}
+  end
+
   if Application.compile_env(:ortex, :add_backend_on_inspect, true) do
     defp maybe_add_signature(result, %T{data: %B{ref: _mat_ref}}) do
       Inspect.Algebra.concat([

--- a/lib/ortex/native.ex
+++ b/lib/ortex/native.ex
@@ -26,4 +26,6 @@ defmodule Ortex.Native do
     do: :erlang.nif_error(:nif_not_loaded)
 
   def reshape(_tensor, _shape), do: :erlang.nif_error(:nif_not_loaded)
+
+  def concatenate(_tensors_refs, _type, _axis), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/ortex/src/lib.rs
+++ b/native/ortex/src/lib.rs
@@ -93,6 +93,18 @@ pub fn reshape<'a>(
     Ok(ResourceArc::new(tensor.reshape(shape)?))
 }
 
+#[rustler::nif]
+pub fn concatenate<'a>(
+    tensors: Vec<ResourceArc<OrtexTensor>>,
+    dtype: Term,
+    axis: i32,
+) -> NifResult<ResourceArc<OrtexTensor>> {
+    let (dtype_t, dtype_bits): (Term, usize) = dtype.decode()?;
+    let dtype_str = dtype_t.atom_to_string()?;
+    let concatted = tensor::concatenate(tensors, (&dtype_str, dtype_bits), axis as usize);
+    Ok(ResourceArc::new(concatted))
+}
+
 rustler::init!(
     "Elixir.Ortex.Native",
     [
@@ -102,7 +114,8 @@ rustler::init!(
         to_binary,
         show_session,
         slice,
-        reshape
+        reshape,
+        concatenate
     ],
     load = |env: Env, _| {
         rustler::resource!(OrtexModel, env);

--- a/native/ortex/src/tensor.rs
+++ b/native/ortex/src/tensor.rs
@@ -3,6 +3,7 @@ use ndarray::prelude::*;
 use ndarray::{ArrayBase, ArrayView, Data, IxDyn};
 use ort::tensor::{DynOrtTensor, FromArray, InputTensor, TensorElementDataType};
 use ort::OrtError;
+use rustler::resource::ResourceArc;
 use rustler::Atom;
 
 use crate::constants::ortex_atoms;
@@ -276,4 +277,257 @@ impl std::convert::TryFrom<&DynOrtTensor<'_, IxDyn>> for OrtexTensor {
             TensorElementDataType::String | TensorElementDataType::Bool => todo!(),
         }
     }
+}
+
+// Currently only supports concatenating tenors of the same type.
+//
+// This is a similar structure to the above match clauses, except each function
+// in map is more complex and needs to be written out explicitly, see below.
+//
+// Each fn concatenate_{type} verifies to the compiler that the vec<OrtexTensor>
+// all have the same type, and then we can concat easily from there
+//
+// TODO: make the fn concatenate_{type} a macro?
+pub fn concatenate(
+    tensors: Vec<ResourceArc<OrtexTensor>>,
+    dtype: (&str, usize),
+    axis: usize,
+) -> OrtexTensor {
+    match dtype {
+        ("s", 8) => concatenate_s8(tensors, axis),
+        ("s", 16) => concatenate_s16(tensors, axis),
+        ("s", 32) => concatenate_s32(tensors, axis),
+        ("s", 64) => concatenate_s64(tensors, axis),
+        ("u", 8) => concatenate_u8(tensors, axis),
+        ("u", 16) => concatenate_u16(tensors, axis),
+        ("u", 32) => concatenate_u32(tensors, axis),
+        ("u", 64) => concatenate_u64(tensors, axis),
+        ("f", 16) => concatenate_f16(tensors, axis),
+        ("bf", 16) => concatenate_bf16(tensors, axis),
+        ("f", 32) => concatenate_f32(tensors, axis),
+        ("f", 64) => concatenate_f64(tensors, axis),
+        _ => unimplemented!(),
+    }
+}
+
+// each of the below concatenate_{x} functions are identical except for the
+// underlying data-type / OrtexTensor enum
+fn concatenate_s8(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    // very hacky way to type coalesce, filter_map using an option
+    fn filter_s8(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&i8>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::s8(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    // now all tensors have the same type after filter_map()-ing
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&i8>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_s8(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+
+    // because concatenating creates a non-standard data format, we copy the
+    // data into a standard format shape. Otherwise, when converting to a
+    // binary, the tensor's data is not ordered properly
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::s8(x)
+}
+
+fn concatenate_s16(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_s16(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&i16>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::s16(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&i16>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_s16(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::s16(x)
+}
+
+fn concatenate_s32(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_s32(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&i32>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::s32(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&i32>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_s32(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::s32(x)
+}
+
+fn concatenate_s64(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_s64(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&i64>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::s64(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&i64>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_s64(val)).collect();
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::s64(x)
+}
+
+fn concatenate_u8(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_u8(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&u8>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::u8(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&u8>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_u8(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::u8(x)
+}
+
+fn concatenate_u16(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_u16(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&u16>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::u16(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&u16>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_u16(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::u16(x)
+}
+
+fn concatenate_u32(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_u32(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&u32>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::u32(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&u32>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_u32(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::u32(x)
+}
+
+fn concatenate_u64(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_u64(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&u64>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::u64(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&u64>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_u64(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::u64(x)
+}
+
+fn concatenate_f16(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_f16(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&half::f16>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::f16(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&half::f16>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_f16(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::f16(x)
+}
+
+fn concatenate_bf16(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_bf16(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&half::bf16>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::bf16(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&half::bf16>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_bf16(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::bf16(x)
+}
+
+fn concatenate_f32(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_f32(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&f32>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::f32(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&f32>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_f32(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::f32(x)
+}
+
+fn concatenate_f64(tensors: Vec<ResourceArc<OrtexTensor>>, axis: usize) -> OrtexTensor {
+    fn filter_f64(
+        of: &OrtexTensor,
+    ) -> Option<ArrayBase<ndarray::ViewRepr<&f64>, Dim<ndarray::IxDynImpl>>> {
+        match of {
+            OrtexTensor::f64(x) => Some(x.view()),
+            _ => None,
+        }
+    }
+
+    let tensors: Vec<ArrayBase<ndarray::ViewRepr<&f64>, Dim<ndarray::IxDynImpl>>> =
+        tensors.iter().filter_map(|val| filter_f64(val)).collect();
+
+    let x = ndarray::concatenate(Axis(axis), &tensors).unwrap();
+    let x = Array::from_shape_vec(x.raw_dim(), x.iter().cloned().collect()).unwrap();
+    OrtexTensor::f64(x)
 }

--- a/test/shape/concat_test.exs
+++ b/test/shape/concat_test.exs
@@ -1,0 +1,150 @@
+defmodule Ortex.TestConcat do
+  use ExUnit.Case
+
+  # Testing each type, since there's a bunch of boilerplate that we want to 
+  # check for errors on the Rust side
+  %{
+    "s8" => {:s, 8},
+    "s16" => {:s, 16},
+    "s32" => {:s, 16},
+    "s64" => {:s, 16},
+    "u8" => {:s, 16},
+    "u16" => {:s, 16},
+    "u32" => {:s, 16},
+    "u64" => {:s, 16},
+    "f16" => {:s, 16},
+    "bf16" => {:s, 16},
+    "f32" => {:s, 16},
+    "f64" => {:s, 16}
+  }
+  |> Enum.each(fn {type_str, type_tuple} ->
+    test "Concat 1d tensors #{type_str}" do
+      t1 =
+        Nx.tensor([1, 2, 3, 4], type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      t2 =
+        Nx.tensor([1, 2, 3, 4], type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      concatted = Nx.concatenate([t1, t2]) |> Nx.backend_transfer()
+      expected = Nx.tensor([1, 2, 3, 4, 1, 2, 3, 4], type: unquote(type_tuple))
+      assert concatted == expected
+    end
+
+    test "Concat 3d tensors #{type_str}" do
+      o1 = Nx.iota({2, 3, 5}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+      o2 = Nx.iota({1, 3, 5}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+      concatted = Nx.concatenate([o1, o2]) |> Nx.backend_transfer()
+      expected = Nx.concatenate([o1 |> Nx.backend_transfer(), o2 |> Nx.backend_transfer()])
+      assert concatted == expected
+    end
+
+    test "Concat 3 #{type_str} vectors" do
+      t1 =
+        Nx.tensor([1, 2, 3, 4], type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      t2 =
+        Nx.tensor([1, 2, 3, 4], type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      t3 =
+        Nx.tensor([1, 2, 3, 4], type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      concatted = Nx.concatenate([t1, t2, t3]) |> Nx.backend_transfer()
+      expected = Nx.tensor([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4], type: unquote(type_tuple))
+      assert concatted == expected
+    end
+
+    test "Concat axis #{type_str} 1" do
+      o1 = Nx.iota({3, 5}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+      o2 = Nx.iota({3, 5}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      concatted = Nx.concatenate([o1, o2], axis: 1) |> Nx.backend_transfer()
+
+      n1 = Nx.iota({3, 5}, type: unquote(type_tuple))
+      n2 = Nx.iota({3, 5}, type: unquote(type_tuple))
+
+      expected = Nx.concatenate([n1, n2], axis: 1)
+      assert concatted == expected
+    end
+
+    test "Concat axis 1 of three 3-dimensional #{type_str} vector" do
+      t1 = Nx.iota({3, 5, 7}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+      t2 = Nx.iota({3, 5, 7}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+      t3 = Nx.iota({3, 5, 7}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      concatted = Nx.concatenate([t1, t2, t3], axis: 1) |> Nx.backend_transfer()
+
+      expected =
+        Nx.concatenate(
+          [
+            Nx.iota({3, 5, 7}, type: unquote(type_tuple)),
+            Nx.iota({3, 5, 7}, type: unquote(type_tuple)),
+            Nx.iota({3, 5, 7}, type: unquote(type_tuple))
+          ],
+          axis: 1
+        )
+
+      assert concatted == expected
+    end
+
+    test "Concat axis 2 of three 3-dimensional #{type_str} vector" do
+      t1 = Nx.iota({3, 5, 7}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+      t2 = Nx.iota({3, 5, 7}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+      t3 = Nx.iota({3, 5, 7}, type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      concatted = Nx.concatenate([t1, t2, t3], axis: 2) |> Nx.backend_transfer()
+
+      expected =
+        Nx.concatenate(
+          [
+            Nx.iota({3, 5, 7}, type: unquote(type_tuple)),
+            Nx.iota({3, 5, 7}, type: unquote(type_tuple)),
+            Nx.iota({3, 5, 7}, type: unquote(type_tuple))
+          ],
+          axis: 2
+        )
+
+      assert concatted == expected
+    end
+
+    test "Concat doesn't alter component #{type_str} vectors" do
+      t1 =
+        Nx.tensor([1, 2, 3, 4], type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      t2 =
+        Nx.tensor([1, 2, 3, 4], type: unquote(type_tuple)) |> Nx.backend_transfer(Ortex.Backend)
+
+      concatted = Nx.concatenate([t1, t2]) |> Nx.backend_transfer()
+      second_concatted = Nx.concatenate([t1, t2]) |> Nx.backend_transfer()
+
+      assert concatted == second_concatted
+    end
+  end)
+
+  test "Concat fails to concat vectors of differing types" do
+    assert_raise RuntimeError,
+                 "Ortex does not currently support concatenation of vectors with differing types.",
+                 fn ->
+                   t1 = Nx.tensor([1, 2, 3], type: {:s, 16}) |> Nx.backend_transfer(Ortex.Backend)
+                   t2 = Nx.tensor([1, 2, 3], type: {:s, 32}) |> Nx.backend_transfer(Ortex.Backend)
+                   _err = Nx.concatenate([t1, t2])
+                 end
+  end
+
+  # Ignoring these tests, as Nx.Shape takes care of determining if the shape is valid
+
+  # test "Concat fails to concat vectors with invalid default axis" do
+  #   assert_raise ArgumentError, "expected all shapes to match {*, 5, 7}, got unmatching shape: {2, 4, 7}", fn() -> 
+  #     t1 = Nx.iota({3, 5, 7}) |> Nx.backend_transfer(Ortex.Backend)
+  #     t2 = Nx.iota({2, 4, 7}) |> Nx.backend_transfer(Ortex.Backend)
+  #     _err = Nx.concatenate([t1, t2])
+  #   end
+  # end
+
+  # test "Concat fails to concat vectors with invalid provided axis" do
+  #   assert_raise ArgumentError, "different dims, given axis" do 
+  #     t1 = Nx.iota({3, 5, 7}) |> Nx.backend_transfer(Ortex.Backend)
+  #     t2 = Nx.iota({2, 4, 7}) |> Nx.backend_transfer(Ortex.Backend)
+  #     _err = Nx.concatenate([t1, t2], axis: 2)
+  #   end
+  # end
+end

--- a/test/shape/concat_test.exs
+++ b/test/shape/concat_test.exs
@@ -129,22 +129,4 @@ defmodule Ortex.TestConcat do
                    _err = Nx.concatenate([t1, t2])
                  end
   end
-
-  # Ignoring these tests, as Nx.Shape takes care of determining if the shape is valid
-
-  # test "Concat fails to concat vectors with invalid default axis" do
-  #   assert_raise ArgumentError, "expected all shapes to match {*, 5, 7}, got unmatching shape: {2, 4, 7}", fn() -> 
-  #     t1 = Nx.iota({3, 5, 7}) |> Nx.backend_transfer(Ortex.Backend)
-  #     t2 = Nx.iota({2, 4, 7}) |> Nx.backend_transfer(Ortex.Backend)
-  #     _err = Nx.concatenate([t1, t2])
-  #   end
-  # end
-
-  # test "Concat fails to concat vectors with invalid provided axis" do
-  #   assert_raise ArgumentError, "different dims, given axis" do 
-  #     t1 = Nx.iota({3, 5, 7}) |> Nx.backend_transfer(Ortex.Backend)
-  #     t2 = Nx.iota({2, 4, 7}) |> Nx.backend_transfer(Ortex.Backend)
-  #     _err = Nx.concatenate([t1, t2], axis: 2)
-  #   end
-  # end
 end


### PR DESCRIPTION
Allows for concatenating n tensors, given that the tensors have the same underlying type. Will raise a runtime error if they have a different type. Should partially close #11 (still need to allow for concatenating tensors with varying types). 