### PR TITLE
Rustler crate compilation changes

### DIFF
--- a/lib/ortex/native.ex
+++ b/lib/ortex/native.ex
@@ -10,7 +10,8 @@ defmodule Ortex.Native do
 
   use Rustler,
     otp_app: :ortex,
-    crate: :ortex
+    crate: :ortex,
+    skip_compilation?: true
 
   # When loading a NIF module, dummy clauses for all NIF function are required.
   # NIF dummies usually just error out when called when the NIF is not loaded, as that should never normally happen.

--- a/lib/ortex/native.ex
+++ b/lib/ortex/native.ex
@@ -1,11 +1,21 @@
 defmodule Ortex.Native do
   @moduledoc false
 
+  @rustler_version Application.spec(:rustler, :vsn) |> to_string() |> Version.parse!()
+
   # We have to compile the crate before `use Rustler` compiles the crate since
   # cargo downloads the onnxruntime shared libraries and they are not available
   # to load or copy into Elixir's during the on_load or Elixir compile steps.
   # In the future, this may be configurable in Rustler.
-  Rustler.Compiler.compile_crate(__MODULE__, otp_app: :ortex, crate: :ortex)
+  if Version.compare(@rustler_version, "0.30.0") in [:gt, :eq] do
+    Rustler.Compiler.compile_crate(:ortex, Application.compile_env(:ortex, __MODULE__, []),
+      otp_app: :ortex,
+      crate: :ortex
+    )
+  else
+    Rustler.Compiler.compile_crate(__MODULE__, otp_app: :ortex, crate: :ortex)
+  end
+
   Ortex.Util.copy_ort_libs()
 
   use Rustler,

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Ortex.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:rustler, "~> 0.29.0"},
+      {:rustler, "~> 0.27"},
       {:nx, "~> 0.6"},
       {:tokenizers, "~> 0.4", only: :dev},
       {:ex_doc, "0.29.4", only: :dev, runtime: false},


### PR DESCRIPTION
fixes #33 

- 0.27 was the earliest Rustler version I found that worked without further modification
- the version dependency is `~> 0.27` - it may break in the future with further `rustler` changes, but I would guess the frequency of this should be very low
- I set the `skip_compilation?` option to true, since we have already compiled the crate. I may be missing something here though