### PR TITLE
Boolean input support

### DIFF
--- a/native/ortex/src/model.rs
+++ b/native/ortex/src/model.rs
@@ -116,7 +116,7 @@ pub fn run(
             )[..],
         );
 
-        // NOTE: try_into impl here will implicitly map bool outputs to signed i8 outputs
+        // NOTE: try_into impl here will implicitly map bool outputs to u8 outputs
         let ortextensor: OrtexTensor = val.try_into()?;
         let shape = ortextensor.shape();
         let (dtype, bits) = ortextensor.dtype();

--- a/native/ortex/src/tensor.rs
+++ b/native/ortex/src/tensor.rs
@@ -1,5 +1,6 @@
 //! Conversions for packing/unpacking `OrtexTensor`s into different types
 use core::convert::TryFrom;
+use half::{bf16, f16};
 use ndarray::prelude::*;
 use ndarray::{ArrayBase, ArrayView, Data, IxDyn, IxDynImpl, ViewRepr};
 use ort::{DynValue, Error, Value};
@@ -26,6 +27,9 @@ pub enum OrtexTensor {
     bf16(Array<half::bf16, IxDyn>),
     f32(Array<f32, IxDyn>),
     f64(Array<f64, IxDyn>),
+    // the bool input is for internal use only.
+    // Any Nx facing ops should panic if called on a bool input
+    bool(Array<bool, IxDyn>),
 }
 
 impl OrtexTensor {
@@ -43,6 +47,7 @@ impl OrtexTensor {
             OrtexTensor::bf16(y) => y.shape().to_owned(),
             OrtexTensor::f32(y) => y.shape().to_owned(),
             OrtexTensor::f64(y) => y.shape().to_owned(),
+            _ => panic!("Can't convert this type to Nx format"),
         }
     }
 
@@ -108,6 +113,7 @@ impl OrtexTensor {
                     .into_shape_with_order(shape)
                     .map_err(|e| rustler::Error::Term(Box::new(e.to_string())))?,
             )),
+            _ => panic!("Can't convert this type to Nx format"),
         }
     }
 
@@ -125,6 +131,7 @@ impl OrtexTensor {
             OrtexTensor::bf16(_) => (ortex_atoms::bf(), 16),
             OrtexTensor::f32(_) => (ortex_atoms::f(), 32),
             OrtexTensor::f64(_) => (ortex_atoms::f(), 64),
+            _ => panic!("Can't convert this type to Nx format"),
         }
     }
 
@@ -142,6 +149,7 @@ impl OrtexTensor {
             OrtexTensor::bf16(y) => get_bytes(y),
             OrtexTensor::f32(y) => get_bytes(y),
             OrtexTensor::f64(y) => get_bytes(y),
+            _ => panic!("Can't convert this type to Nx format"),
         };
         contents
     }
@@ -173,6 +181,30 @@ impl OrtexTensor {
             OrtexTensor::bf16(y) => OrtexTensor::bf16(slice_array(y, &slice_specs).to_owned()),
             OrtexTensor::f32(y) => OrtexTensor::f32(slice_array(y, &slice_specs).to_owned()),
             OrtexTensor::f64(y) => OrtexTensor::f64(slice_array(y, &slice_specs).to_owned()),
+            _ => panic!("Can't convert this type to Nx format"),
+        }
+    }
+
+    pub fn to_bool(self) -> OrtexTensor {
+        match self {
+            OrtexTensor::s8(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::s16(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::s32(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::s64(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::u8(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::u16(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::u32(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::u64(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0)),
+            OrtexTensor::f16(y) => {
+                OrtexTensor::bool(y.to_owned().mapv(|x| x != f16::ZERO || x != f16::NEG_ZERO))
+            }
+            OrtexTensor::bf16(y) => OrtexTensor::bool(
+                y.to_owned()
+                    .mapv(|x| x != bf16::ZERO || x != bf16::NEG_ZERO),
+            ),
+            OrtexTensor::f32(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0.)),
+            OrtexTensor::f64(y) => OrtexTensor::bool(y.to_owned().mapv(|x| x != 0.)),
+            _ => panic!("Can't convert this type to bool"),
         }
     }
 }
@@ -253,8 +285,10 @@ impl TryFrom<&Value> for OrtexTensor {
             ort::TensorElementType::String => {
                 todo!("Can't return string tensors")
             }
+            // map the output into integer space
             ort::TensorElementType::Bool => {
-                todo!("Can't return bool tensors")
+                let nd_array = e.try_extract_tensor::<bool>()?.into_owned();
+                OrtexTensor::s8(nd_array.mapv(|x| x as i8))
             }
         };
 
@@ -278,8 +312,29 @@ impl TryFrom<&OrtexTensor> for ort::SessionInputValue<'_> {
             OrtexTensor::u16(arr) => arr.clone().try_into()?,
             OrtexTensor::u32(arr) => arr.clone().try_into()?,
             OrtexTensor::u64(arr) => arr.clone().try_into()?,
+            OrtexTensor::bool(arr) => arr.clone().try_into()?,
         };
         Ok(r.into())
+    }
+}
+
+impl Clone for OrtexTensor {
+    fn clone(&self) -> Self {
+        match self {
+            OrtexTensor::s8(t) => OrtexTensor::s8(t.clone()),
+            OrtexTensor::s16(t) => OrtexTensor::s16(t.clone()),
+            OrtexTensor::s32(t) => OrtexTensor::s32(t.clone()),
+            OrtexTensor::s64(t) => OrtexTensor::s64(t.clone()),
+            OrtexTensor::bf16(t) => OrtexTensor::bf16(t.clone()),
+            OrtexTensor::f16(t) => OrtexTensor::f16(t.clone()),
+            OrtexTensor::f32(t) => OrtexTensor::f32(t.clone()),
+            OrtexTensor::f64(t) => OrtexTensor::f64(t.clone()),
+            OrtexTensor::u8(t) => OrtexTensor::u8(t.clone()),
+            OrtexTensor::u16(t) => OrtexTensor::u16(t.clone()),
+            OrtexTensor::u32(t) => OrtexTensor::u32(t.clone()),
+            OrtexTensor::u64(t) => OrtexTensor::u64(t.clone()),
+            OrtexTensor::bool(t) => OrtexTensor::bool(t.clone()),
+        }
     }
 }
 

--- a/native/ortex/src/utils.rs
+++ b/native/ortex/src/utils.rs
@@ -116,3 +116,12 @@ pub fn map_opt_level(opt: i32) -> GraphOptimizationLevel {
         _ => GraphOptimizationLevel::Disable,
     }
 }
+
+pub fn is_bool_input(inp: &ort::ValueType) -> bool {
+    match inp {
+        ort::ValueType::Tensor { ty, .. } => ty == &ort::TensorElementType::Bool,
+        ort::ValueType::Map { value, .. } => value == &ort::TensorElementType::Bool,
+        ort::ValueType::Sequence(boxed_input) => is_bool_input(boxed_input),
+        ort::ValueType::Optional(boxed_input) => is_bool_input(boxed_input),
+    }
+}


### PR DESCRIPTION
Currently, [Nx does not support boolean tensor types](https://hexdocs.pm/nx/Nx.Type.html). However, ONNX models allow for boolean inputs, and certain ONNX ops only allow for boolean inputs (e.g., ONNX `If` nodes require [boolean input](https://onnx.ai/onnx/operators/onnx__If.html)). If a model has an boolean input, it was difficult to run it through Ortex.

One solution (and necessary before this PR), is to modify the ONNX graph by adding a [Cast](https://onnx.ai/onnx/operators/onnx__Cast.html) node, which could casting some Nx compatible type into a boolean. 

This PR introduces a simpler way to allow boolean inputs into Ortex: by automatically casting boolean inputs as necessary. Specifically, Ortex will check the input-type of the input and cast any inputs to a boolean if necessary. Similarly, it will cast any boolean outputs from models into a u8 integer.