### PR TITLE
Uses Inspec.Algebra.to_doc syntax to support Elixir 1.19

### DIFF
--- a/lib/ortex/model.ex
+++ b/lib/ortex/model.ex
@@ -79,9 +79,9 @@ defimpl Inspect, for: Ortex.Model do
           concat([
             color("#Ortex.Model<", :map, inspect_opts),
             line(),
-            nest(concat(["  inputs: ", Inspect.List.inspect(inputs, inspect_opts)]), 2),
+            nest(concat(["  inputs: ", Inspect.Algebra.to_doc(inputs, inspect_opts)]), 2),
             line(),
-            nest(concat(["  outputs: ", Inspect.List.inspect(outputs, inspect_opts)]), 2),
+            nest(concat(["  outputs: ", Inspect.Algebra.to_doc(outputs, inspect_opts)]), 2),
             color(">", :map, inspect_opts)
           ])
         )


### PR DESCRIPTION
In Elixir 1.19 and above, the return for `Inspect.List.inspect/2` changed from `doc` to `{doc, opts}`. This is the recommended call anyway and it fixes the issue for 1.19. ✌️ 